### PR TITLE
Port demonstration IO to h5

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "Arcade-Learning-Environment"]
 	path = Arcade-Learning-Environment
-	url = git@github.com:erictzeng/Arcade-Learning-Environment.git
-        ignore = dirty
+	url = git@github.com:shelhamer/Arcade-Learning-Environment.git

--- a/demonstration.py
+++ b/demonstration.py
@@ -87,7 +87,7 @@ class Demonstration(object):
         del self.actions[t:]
         del self.rewards[t:]
         del self.game_over[t:]
-        
+
     def reset_to_latest_snapshot(self, ale):
         latest = max(self.snapshots.keys())
         self.reset_to_timestep(latest)

--- a/demonstration.py
+++ b/demonstration.py
@@ -79,6 +79,21 @@ class Demonstration(object):
         self.snapshots[len(self)] = ale.encodeState(state_ptr)
         ale.deleteState(state_ptr)
 
+    def restore_timestep(self, ale, t):
+        """
+        Restore the emulator to a certain time step of the demonstration.
+        N.B. Restoring the system state does not give a valid RAM or screen
+        state until a step is taken in the emulator.
+        """
+        assert t > 0, "cannot restore initial state"
+        # restore preceding snapshot
+        snapshot_t = max(filter(lambda idx: idx < t, self.snapshots.keys()))
+        snapshot = ale.decodeState(self.snapshots[snapshot_t])
+        ale.restoreSystemState(snapshot)
+        # seek through demonstration by following actions in emulator
+        for idx in range(snapshot_t, t):
+            ale.act(self.actions[idx])
+
     def reset_to_timestep(self, t):
         for key in self.snapshots.keys():
             if key > t:

--- a/record.py
+++ b/record.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-import random
 import time
 
 import ale_python_interface as ALE
@@ -97,14 +96,14 @@ def resume(partial_demo, output, frames, episodes, rom):
     demo.reset_to_latest_snapshot(ale)
     record(ale, demo, output, frames, episodes)
 
-def record(ale, demo, output, num_frames, num_episodes, snapshot_chance=0.001):
+def record(ale, demo, output, num_frames, num_episodes):
     keystates = {key: False for key in keys}
     score = 0
     clock = pygame.time.Clock()
     episodes = 0
     try:
         while len(demo) < num_frames:
-            if random.uniform(0, 1) < snapshot_chance:
+            if len(demo) % demo.snapshot_interval == 0:
                 demo.snapshot(ale)
             frame = ale.getScreenRGB()
             update_keystates(keystates)

--- a/record.py
+++ b/record.py
@@ -72,6 +72,7 @@ def record_new(rom, output, frames, episodes, seed):
     ale = ALE.ALEInterface()
     ale.setInt('random_seed', seed)
     ale.setFloat('repeat_action_probability', 0)
+    ale.setBool('color_averaging', False)
     ale.setBool('display_screen', True)
     ale.loadROM(rom)
     demo = Demonstration(rom, ale.getMinimalActionSet())
@@ -88,6 +89,7 @@ def resume(partial_demo, output, frames, episodes, rom):
     demo = Demonstration.load(partial_demo)
     ale = ALE.ALEInterface()
     ale.setFloat('repeat_action_probability', 0)
+    ale.setBool('color_averaging', False)
     ale.setBool('display_screen', True)
     if not rom:
         ale.loadROM(demo.rom)


### PR DESCRIPTION
**Don't merge. This is just a sketch.**

Switch from pickling to hdf5 for loading and saving of demonstrations.
This is a more portable format.

TODO
- [ ] decide/fix episode boundaries (loss of life vs. game over, etc.)
- [ ] switch from lists to arrays (might give a speed-up)
- [ ] batch h5 write for each episode?
- [ ] figure out if h5 can go faster}
